### PR TITLE
feat: upload as CAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@ jobs:
     - run: echo ${{ steps.add_to_estuary.outputs.cid }}
 ```
 
-
-## TODO
-
-- How to upload a directory and get a single CID for the root.
-
-
 ## Inputs
 You must provide the `path_to_add` and an `estuary_api_key` to get the magic.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ API Key for Estuary. _required_
 ### estuary_api_url
 URL for Estuary instance and endpoint to POST the files to. 
 
-_Default_ https://shuttle-1.estuary.tech/content/add
+_Default_ https://upload.estuary.tech/content/add
 
 ### gateway_url
 URL for IPFS gateway for preview urls

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ API Key for Estuary. _required_
 ### estuary_api_url
 URL for Estuary instance and endpoint to POST the files to. 
 
-_Default_ https://upload.estuary.tech/content/add
+_Default_ https://shuttle-4.estuary.tech/content/add-car
 
 ### gateway_url
 URL for IPFS gateway for preview urls

--- a/action.yml
+++ b/action.yml
@@ -30,10 +30,10 @@ runs:
   using: "composite"
   steps:
     - name: pack the files into a Content-Addressed Archive (CAR)
-      run: npx ipfs-car --pack ${{ inputs.path_to_add }} --output redhot.car
+      run: npx ipfs-car --pack ${{ inputs.path_to_add }} --output lovely.car
       shell: bash
     - name: add the files to estuary
-      run: 'curl --fail --silent --show-error -X POST ${{ inputs.estuary_api_url }} -H "Authorization: Bearer ${{ inputs.estuary_api_key }}" -H "Accept: application/json" -T redhot.car | tee ./response'
+      run: 'curl -X POST ${{ inputs.estuary_api_url }} -H "Authorization: Bearer ${{ inputs.estuary_api_key }}" -H "Accept: application/json" -T lovely.car | tee ./response'
       shell: bash
     - name: fail if no CID in response
       run: jq -e '.cid' ./response

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
       run: npx ipfs-car --pack ${{ inputs.path_to_add }} --output redhot.car
       shell: bash
     - name: add the files to estuary
-      run: 'curl --fail --silent --show-error -X POST ${{ inputs.estuary_api_url }} -H "Authorization: Bearer ${{ inputs.estuary_api_key }}" -T "redhot.car" -H "Accept: application/json" -H "Content-Type: multipart/form-data" | tee ./response'
+      run: 'curl --fail --silent --show-error -X POST ${{ inputs.estuary_api_url }} -H "Authorization: Bearer ${{ inputs.estuary_api_key }}" -H "Accept: application/json" -T redhot.car | tee ./response'
       shell: bash
     - name: fail if no CID in response
       run: jq -e '.cid' ./response

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,8 @@ inputs:
     description: 'API Key for Estuary'
     required: true
   estuary_api_url:
-    description: 'URL for esturary instance and endpoint to POST the files to. default: https://shuttle-1.estuary.tech/content/add' 
-    default: https://shuttle-1.estuary.tech/content/add
+    description: 'URL for esturary instance and endpoint to POST the files to. default: https://api.estuary.tech/content/add-car' 
+    default: https://api.estuary.tech/content/add-car
     required: true
   gateway_url:
     description: 'URL for IPFS gateway for preview urls' 
@@ -29,8 +29,11 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: pack the files into a Content-Addressed Archive (CAR)
+      run: npx ipfs-car --pack ${{ inputs.path_to_add }} --output redhot.car
+      shell: bash
     - name: add the files to estuary
-      run: 'curl --fail --silent --show-error -X POST ${{ inputs.estuary_api_url }} -H "Authorization: Bearer ${{ inputs.estuary_api_key }}" -F "data=@${{ inputs.path_to_add }}" -H "Accept: application/json" -H "Content-Type: multipart/form-data" | tee ./response'
+      run: 'curl --fail --silent --show-error -X POST ${{ inputs.estuary_api_url }} -H "Authorization: Bearer ${{ inputs.estuary_api_key }}" -T "redhot.car" -H "Accept: application/json" -H "Content-Type: multipart/form-data" | tee ./response'
       shell: bash
     - name: fail if no CID in response
       run: jq -e '.cid' ./response

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,8 @@ inputs:
     description: 'API Key for Estuary'
     required: true
   estuary_api_url:
-    description: 'URL for esturary instance and endpoint to POST the files to. default: https://api.estuary.tech/content/add-car' 
-    default: https://api.estuary.tech/content/add-car
+    description: 'URL for esturary instance and endpoint to POST the files to. default: https://upload.estuary.tech/content/add-car' 
+    default: https://upload.estuary.tech/content/add-car
     required: true
   gateway_url:
     description: 'URL for IPFS gateway for preview urls' 

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
       run: npx ipfs-car --pack ${{ inputs.path_to_add }} --output lovely.car
       shell: bash
     - name: add the files to estuary
-      run: 'curl -X POST ${{ inputs.estuary_api_url }} -H "Authorization: Bearer ${{ inputs.estuary_api_key }}" -H "Accept: application/json" -T lovely.car --silent --show-error | tee ./response'
+      run: 'curl -X POST ${{ inputs.estuary_api_url }} -H "Authorization: Bearer ${{ inputs.estuary_api_key }}" -H "Accept: application/json" -H "Content-Type: multipart/form-data" -F "data=@lovely.car" --silent --show-error | tee ./response'
       shell: bash
     - name: fail if no CID in response
       run: jq -e '.cid' ./response

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
       run: npx ipfs-car --pack ${{ inputs.path_to_add }} --output lovely.car
       shell: bash
     - name: add the files to estuary
-      run: 'curl -X POST ${{ inputs.estuary_api_url }} -H "Authorization: Bearer ${{ inputs.estuary_api_key }}" -H "Accept: application/json" -T lovely.car | tee ./response'
+      run: 'curl -X POST ${{ inputs.estuary_api_url }} -H "Authorization: Bearer ${{ inputs.estuary_api_key }}" -H "Accept: application/json" -T lovely.car --silent --show-error | tee ./response'
       shell: bash
     - name: fail if no CID in response
       run: jq -e '.cid' ./response

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,8 @@ inputs:
     description: 'API Key for Estuary'
     required: true
   estuary_api_url:
-    description: 'URL for esturary instance and endpoint to POST the files to. default: https://upload.estuary.tech/content/add-car' 
-    default: https://upload.estuary.tech/content/add-car
+    description: 'URL for esturary instance and endpoint to POST the files to. default: https://shuttle-4.estuary.tech/content/add-car' 
+    default: https://shuttle-4.estuary.tech/content/add-car 
     required: true
   gateway_url:
     description: 'URL for IPFS gateway for preview urls' 
@@ -33,7 +33,7 @@ runs:
       run: npx ipfs-car --pack ${{ inputs.path_to_add }} --output lovely.car
       shell: bash
     - name: add the files to estuary
-      run: 'curl -X POST ${{ inputs.estuary_api_url }} -H "Authorization: Bearer ${{ inputs.estuary_api_key }}" -H "Accept: application/json" -H "Content-Type: multipart/form-data" -F "data=@lovely.car" --silent --show-error | tee ./response'
+      run: 'curl -X POST ${{ inputs.estuary_api_url }} -H "Authorization: Bearer ${{ inputs.estuary_api_key }}" -H "Accept: application/json" -T lovely.car --silent --show-error | tee ./response'
       shell: bash
     - name: fail if no CID in response
       run: jq -e '.cid' ./response


### PR DESCRIPTION
Estuary now supports uploads as CAR files, so we can now upload an entire directory, like say, a website, and add it all in one and get the CID for the root dir.

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>